### PR TITLE
Fix README bitstream line

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ PAX-Synth-Automation/
 │   ├── matcher.v           # Core Verilog design (simple price matcher)
 │   └── matcher.xdc         # I/O constraints for xc7k160tfbg484-1
 ├── scripts/
-│   └── synth.bat           # Batch file automating Vivado synthesis + bitstream generation
+│   └── synth.bat           # Automates synth + bitstream generation
 ├── output/
 │   └── matcher.bit         # Generated bitstream file
 ├── README.md               # You're reading this


### PR DESCRIPTION
## Summary
- keep the file tree table intact
- shorten the `synth.bat` description so the bitstream generation line is single-line

## Testing
- `make test` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_685ae2084b1c8329b04cefb31247454d